### PR TITLE
Avoid infinite loop checking if the pathname ends with @subsite

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,15 +26,15 @@ export default (config) => {
             key: 'subsite',
             promise: ({ location, store: { dispatch } }) =>
               __SERVER__ &&
+              !location.pathname.match(/.*@subsite$/) &&
               dispatch(
                 getSubsite(
                   config.settings.apiPath +
-                    flattenToAppURL(location.pathname + '@subsite'),
+                  flattenToAppURL(location.pathname + '@subsite'),
                 ),
               ),
           });
         }
-
         return dispatchActions;
       },
     },


### PR DESCRIPTION
In Volto 14 and the last release Volto goes into an infinite loop and doesn't run correctly.

